### PR TITLE
Add Rubberduck to tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,7 @@ Code review is the systematic examination (sometimes referred to as peer review)
 - [Phabricator](https://www.phacility.com/phabricator/) Open source git/mercurial/svn code review tool originating out of Facebook.
 - [Reviewable](https://reviewable.io/) Code review tool built on top of Github Pull Requests.
 - [Review Board](https://www.reviewboard.org/) Open source review tool that is SCM/platform neutral.
+- [Rubberduck](https://www.rubberduck.io) Browser extension to adds code-aware navigation to GitHub pull requests.
 - [Upsource](https://www.jetbrains.com/upsource/) JetBrain's on-premise git/mercurial/perforce/svn code review tool.
 
 ## Contribute


### PR DESCRIPTION
This change adds [Rubberduck](https://www.rubberduck.io) to the list of tools.