### PR TITLE
add Axolo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,11 +8,15 @@ Code review is the systematic examination (sometimes referred to as peer review)
 
 ## Contents
 
-- [Academic Papers](#academic-papers)
-- [Articles](#articles)
-- [Books](#books)
-- [Talks and Podcasts](#talks-and-podcasts)
-- [Tools](#tools)
+- [Awesome Code Review ![Awesome](https://github.com/sindresorhus/awesome)](#awesome-code-review-)
+  - [Contents](#contents)
+  - [Academic Papers](#academic-papers)
+  - [Articles](#articles)
+  - [Books](#books)
+  - [Talks and Podcasts](#talks-and-podcasts)
+  - [Tools](#tools)
+  - [Contribute](#contribute)
+  - [License](#license)
 
 ## Academic Papers
 
@@ -74,6 +78,7 @@ Code review is the systematic examination (sometimes referred to as peer review)
 
 ## Tools
 
+- [Axolo](https://www.axolo.co) Github/GitLab Slack integration. Create one ephemeral channel per pull request/ merge request.
 - [Crucible](https://www.atlassian.com/software/crucible) Atlassian's on-premise code review tool.
 - [Gerrit](https://www.gerritcodereview.com/) Open source git code review tool originating out of Google.
 - [GitHub](https://github.com) Git hosting and pioneer of the "Pull Request".
@@ -82,7 +87,6 @@ Code review is the systematic examination (sometimes referred to as peer review)
 - [LGTM](https://lgtm.com) Automated Git code review for GitHub and Bitbucket pull requests for finding security vulnerabilities and code quality issues.
 - [Phabricator](https://www.phacility.com/phabricator/) Open source git/mercurial/svn code review tool originating out of Facebook.
 - [PullRequest](https://www.pullrequest.com/) Code review as a service for GitHub pull requests.
-- [Pull Reminders](https://pullreminders.com) Automated Slack reminders and metrics for GitHub pull requests.
 - [Reviewable](https://reviewable.io/) Code review tool built on top of GitHub pull requests.
 - [Review Board](https://www.reviewboard.org/) Open source review tool that is SCM/platform neutral.
 - [Rubberduck](https://www.rubberduck.io) Browser extension to adds code-aware navigation to GitHub pull requests.

--- a/readme.md
+++ b/readme.md
@@ -9,14 +9,14 @@ Code review is the systematic examination (sometimes referred to as peer review)
 ## Contents
 
 - [Awesome Code Review ![Awesome](https://github.com/sindresorhus/awesome)](#awesome-code-review-)
-  - [Contents](#contents)
-  - [Academic Papers](#academic-papers)
-  - [Articles](#articles)
-  - [Books](#books)
-  - [Talks and Podcasts](#talks-and-podcasts)
-  - [Tools](#tools)
-  - [Contribute](#contribute)
-  - [License](#license)
+- [Contents](#contents)
+- [Academic Papers](#academic-papers)
+- [Articles](#articles)
+- [Books](#books)
+- [Talks and Podcasts](#talks-and-podcasts)
+- [Tools](#tools)
+- [Contribute](#contribute)
+- [License](#license)
 
 ## Academic Papers
 


### PR DESCRIPTION
Hey, 

- add Axolo to the list of tools
- Took off Pull Reminders as they got acquired by GitHub a few years back and no longer exists. 
- Add missing part of the table of content

Cheers