### PR TITLE
Add git-lrc to tools section in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,7 @@ Code review is the systematic examination (sometimes referred to as peer review)
 
 ## Tools
 
+- [git-lrc](https://github.com/HexmosTech/git-lrc) Free, Unlimited AI Code Reviews That Run on Commit.
 - [Axolo](https://www.axolo.co) Github/GitLab Slack integration. Create one ephemeral channel per pull request/ merge request.
 - [Crucible](https://www.atlassian.com/software/crucible) Atlassian's on-premise code review tool.
 - [Gerrit](https://www.gerritcodereview.com/) Open source git code review tool originating out of Google.


### PR DESCRIPTION
We just launched our project on GitHub — **git-lrc**.

**It runs AI code reviews just before every commit**. Completely free. No limits.

We recently hit [#3 Product of the Day on Product Hunt](https://www.producthunt.com/products/git-lrc?launch=git-lrc), which was a huge push from the community.

The goal is simple: make AI code review engineer-centric and accessible to every developer.

Would really appreciate it if you could take a look. 
And if you like what we’re building, 
please drop a ⭐ on GitHub and accept the PR— that early support genuinely makes a difference.

[https://github.com/HexmosTech/git-lrc](https://github.com/HexmosTech/git-lrc)

Thanks a ton :)