### PR TITLE
Add git-lrc to code review tools list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ Code review is the systematic examination (sometimes referred to as peer review)
 - [Axolo](https://www.axolo.co) Github/GitLab Slack integration. Create one ephemeral channel per pull request/ merge request.
 - [Crucible](https://www.atlassian.com/software/crucible) Atlassian's on-premise code review tool.
 - [Gerrit](https://www.gerritcodereview.com/) Open source git code review tool originating out of Google.
+- [git-lrc](https://github.com/HexmosTech/git-lrc) - Free, Unlimited AI Code Reviews That Run on Every Commit.
 - [GitHub](https://github.com) Git hosting and pioneer of the "Pull Request".
 - [Gitpod](https://gitpod.io) Code review pull requests in a full IDE within your browser.
 - [LGTM](https://lgtm.com) Automated Git code review for GitHub and Bitbucket pull requests for finding security vulnerabilities and code quality issues.


### PR DESCRIPTION
We just launched our project on GitHub — **git-lrc**.

**It runs AI code reviews just before every commit**. Completely free. No limits.

We recently hit [#3 Product of the Day on Product Hunt](https://www.producthunt.com/products/git-lrc?launch=git-lrc), which was a huge push from the community.

The goal is simple: make AI code review engineer-centric and accessible to every developer.

Would really appreciate it if you could take a look. 
And if you like what we’re building, 
please drop a ⭐ on GitHub and accept the PR— that early support genuinely makes a difference.

[https://github.com/HexmosTech/git-lrc](https://github.com/HexmosTech/git-lrc)

Thanks a ton :)