### PR TITLE
Add Git AutoReview to Tools section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ Code review is the systematic examination (sometimes referred to as peer review)
 - [Axolo](https://www.axolo.co) Github/GitLab Slack integration. Create one ephemeral channel per pull request/ merge request.
 - [Crucible](https://www.atlassian.com/software/crucible) Atlassian's on-premise code review tool.
 - [Gerrit](https://www.gerritcodereview.com/) Open source git code review tool originating out of Google.
+- [Git AutoReview](https://gitautoreview.com) AI-powered VS Code extension that reviews pull requests using three models (Claude, GPT, Gemini) to catch bugs, security issues, and performance problems across GitHub, GitLab, and Bitbucket.
 - [GitHub](https://github.com) Git hosting and pioneer of the "Pull Request".
 - [Gitpod](https://gitpod.io) Code review pull requests in a full IDE within your browser.
 - [LGTM](https://lgtm.com) Automated Git code review for GitHub and Bitbucket pull requests for finding security vulnerabilities and code quality issues.


### PR DESCRIPTION
Added **Git AutoReview** to the Tools section in alphabetical order (between Gerrit and GitHub).

## What it does

Git AutoReview is a VS Code extension that runs AI code review on pull requests using Claude, GPT, and Gemini. But the part that matters for this list: it doesn't auto-post comments to your PR like most AI review bots do.

Every suggestion appears as a draft inside VS Code. You read it, decide if it's useful, edit the wording if needed, and only then does it get published to your pull request. That human-in-the-loop step is the whole point — AI hallucinates often enough that a review tool without an approval gate creates noise instead of value.

## What makes it different from the other tools already on this list

- **You approve before publish** — nothing hits your PR without your say-so
- **Three AI models** — Claude, Gemini, GPT. Run two in parallel for a second opinion
- **Pre-commit review** — review staged changes before they enter git history, not just after a PR exists
- **Review profiles** — swap between security-focused, performance, or style rules per repo
- **BYOK** — bring your own API key, code goes directly to your AI provider. If you already pay for Claude Code or GitHub Copilot, the extension costs nothing extra
- **All three platforms** — GitHub, GitLab (including Self-Managed), Bitbucket (including Server/DC)

Free tier: 10 reviews/day, no expiry, no credit card.

- **Website:** https://gitautoreview.com
- **VS Code Marketplace:** https://marketplace.visualstudio.com/items?itemName=vitalii4reva.git-autoreview